### PR TITLE
Add unit tests and update Jest config

### DIFF
--- a/app/tools/air-duct-sizer/tests/utils.test.ts
+++ b/app/tools/air-duct-sizer/tests/utils.test.ts
@@ -1,0 +1,35 @@
+import { formatVelocity, formatPressureLoss, calculateEquivalentDiameter, convertDuctShape } from '../utils';
+
+describe('formatVelocity', () => {
+  test('returns optimal status for supply air', () => {
+    const res = formatVelocity(1500, 'supply');
+    expect(res.status).toBe('optimal');
+    expect(res.unit).toBe('ft/min');
+  });
+
+  test('returns error status for very high velocity', () => {
+    const res = formatVelocity(3000, 'supply');
+    expect(res.status).toBe('error');
+  });
+});
+
+describe('formatPressureLoss', () => {
+  test('categorizes pressure loss', () => {
+    expect(formatPressureLoss(0.04).status).toBe('good');
+    expect(formatPressureLoss(0.09).status).toBe('high');
+  });
+});
+
+describe('calculateEquivalentDiameter', () => {
+  test('calculates based on width and height', () => {
+    const val = calculateEquivalentDiameter(10, 8);
+    expect(val).toBeGreaterThan(0);
+  });
+});
+
+describe('convertDuctShape', () => {
+  test('rectangular to circular conversion', () => {
+    const res = convertDuctShape('rectangular', 'circular', { width: 12, height: 8 });
+    expect(res.diameter).toBeDefined();
+  });
+});

--- a/app/tools/estimating-app/tests/calculations.test.js
+++ b/app/tools/estimating-app/tests/calculations.test.js
@@ -1,7 +1,0 @@
-import { laborCost } from '../calculations/labor.js';
-
-describe('laborCost', () => {
-  test('multiplies hours by rate', () => {
-    expect(laborCost(2, 50)).toBe(100);
-  });
-});

--- a/app/tools/estimating-app/tests/calculations.test.ts
+++ b/app/tools/estimating-app/tests/calculations.test.ts
@@ -1,0 +1,30 @@
+import { laborCost } from '../calculations/labor.js';
+import { materialCost } from '../calculations/material.js';
+import { applyMarkup } from '../calculations/markup.js';
+import { parseTakeoff } from '../components/TakeoffInput.js';
+
+describe('materialCost', () => {
+  test('calculates total material cost', () => {
+    expect(materialCost(10, 5)).toBe(50);
+  });
+});
+
+describe('applyMarkup', () => {
+  test('adds markup percent correctly', () => {
+    expect(applyMarkup(100, 10)).toBe(110);
+  });
+});
+
+describe('parseTakeoff', () => {
+  test('parses raw input object', () => {
+    const raw = { item: 'diffuser', quantity: '4', unit: 'ea' };
+    const parsed = parseTakeoff(raw);
+    expect(parsed).toEqual({ item: 'diffuser', quantity: 4, unit: 'ea' });
+  });
+});
+
+describe('laborCost', () => {
+  test('multiplies hours by rate', () => {
+    expect(laborCost(2, 50)).toBe(100);
+  });
+});

--- a/app/tools/estimating-app/tests/validator.test.ts
+++ b/app/tools/estimating-app/tests/validator.test.ts
@@ -1,0 +1,14 @@
+import { validateSchedule } from '../validators/schedule.js';
+
+const validData = { task: 'Install duct', hours: 8 };
+
+describe('validateSchedule', () => {
+  test('returns true for valid data', () => {
+    expect(validateSchedule(validData)).toBe(true);
+  });
+
+  test('throws for invalid data', () => {
+    const bad = { task: 'Install', hours: -5 };
+    expect(() => validateSchedule(bad)).toThrow();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,24 +2,24 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/test-utils/setup.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@/app/(.*)$': '<rootDir>/app/$1',
   },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.[tj]sx?$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   collectCoverageFrom: [
-    'src/**/*.{ts,tsx}',
-    'app/**/*.{ts,tsx}',
+    'src/**/*.{ts,tsx,js,jsx}',
+    'app/**/*.{ts,tsx,js,jsx}',
     '!src/**/*.d.ts',
     '!src/test-utils/**',
   ],
   testMatch: [
-    '<rootDir>/src/**/__tests__/**/*.{ts,tsx}',
-    '<rootDir>/app/**/__tests__/**/*.{ts,tsx}',
-    '<rootDir>/src/**/*.{test,spec}.{ts,tsx}',
-    '<rootDir>/app/**/*.{test,spec}.{ts,tsx}',
+    '<rootDir>/src/**/__tests__/**/*.{ts,tsx,js,jsx}',
+    '<rootDir>/app/**/__tests__/**/*.{ts,tsx,js,jsx}',
+    '<rootDir>/src/**/*.{test,spec}.{ts,tsx,js,jsx}',
+    '<rootDir>/app/**/*.{test,spec}.{ts,tsx,js,jsx}',
   ],
 };


### PR DESCRIPTION
## Summary
- fix Jest configuration for JS files
- add utility tests for air duct sizing
- expand estimating-app tests to cover calculations and validation

## Testing
- `npx jest@29 --runInBand --coverage --passWithNoTests` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e65cc454832186591dcb6336ca63