### PR TITLE
Add StarBorder demo component

### DIFF
--- a/src/components/ui/StarBorder.tsx
+++ b/src/components/ui/StarBorder.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface StarBorderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const StarBorder = React.forwardRef<HTMLDivElement, StarBorderProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('relative inline-block text-primary-600 dark:text-primary-300', className)}
+        {...props}
+      >
+        <svg
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+        >
+          <polygon
+            points="50,5 61,35 95,35 68,57 79,90 50,70 21,90 32,57 5,35 39,35"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+        </svg>
+        <div className="relative p-4">{children}</div>
+      </div>
+    );
+  }
+);
+
+StarBorder.displayName = 'StarBorder';
+
+export default StarBorder;

--- a/src/components/ui/StarBorderDemo.tsx
+++ b/src/components/ui/StarBorderDemo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import StarBorder from './StarBorder';
+
+const StarBorderDemo: React.FC = () => {
+  return (
+    <div className="flex items-center justify-center p-8 bg-gray-100 dark:bg-gray-900">
+      <StarBorder>Theme-aware Border</StarBorder>
+    </div>
+  );
+};
+
+export default StarBorderDemo;

--- a/src/components/ui/__tests__/StarBorder.test.tsx
+++ b/src/components/ui/__tests__/StarBorder.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import StarBorder from '../StarBorder';
+
+describe('StarBorder', () => {
+  it('renders children', () => {
+    render(<StarBorder>Test Content</StarBorder>);
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `StarBorder` component that draws a star-shaped border
- provide `StarBorderDemo` example for quick visual testing
- include simple unit test for `StarBorder`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b14a340588321a46407356628d8fe