### PR TITLE
Fix estimating subfolder readmes

### DIFF
--- a/app/tools/estimating-app/calculations/README.md
+++ b/app/tools/estimating-app/calculations/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Core estimating math for labor, material, and markup calculations used by the estimating module.

--- a/app/tools/estimating-app/components/README.md
+++ b/app/tools/estimating-app/components/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# UI widgets such as takeoff tables and bid summaries that connect to layouts and calculation logic.

--- a/app/tools/estimating-app/data/README.md
+++ b/app/tools/estimating-app/data/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Sample takeoff data, default rates, and template bids for testing and demonstration.

--- a/app/tools/estimating-app/docs/README.md
+++ b/app/tools/estimating-app/docs/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Guides and onboarding docs describing how to use the estimating module and follow standards.

--- a/app/tools/estimating-app/exports/README.md
+++ b/app/tools/estimating-app/exports/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Export logic to generate bids in formats like Excel, PDF, and CSV.

--- a/app/tools/estimating-app/schemas/README.md
+++ b/app/tools/estimating-app/schemas/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# JSON schemas validating takeoffs, schedules, and exports using AJV or Zod.

--- a/app/tools/estimating-app/tests/README.md
+++ b/app/tools/estimating-app/tests/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Unit and end-to-end tests verifying estimating calculations and UI components.

--- a/app/tools/estimating-app/ui/README.md
+++ b/app/tools/estimating-app/ui/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Theme files and layout definitions for estimating views.

--- a/app/tools/estimating-app/validators/README.md
+++ b/app/tools/estimating-app/validators/README.md
@@ -1,1 +1,1 @@
-# Placeholder
+# Rules verifying takeoff and schedule data for code compliance and completeness.


### PR DESCRIPTION
## Summary
- document estimating-app calculations folder
- document estimating-app components folder
- document estimating-app data folder
- document estimating-app docs folder
- document estimating-app exports folder
- document estimating-app schemas folder
- document estimating-app tests folder
- document estimating-app ui folder
- document estimating-app validators folder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b14a76b448321aded81082de672c7