### PR TITLE
Fix Playwright dev server URL and update guide

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -118,6 +118,20 @@ export default YourToolUI;
 - Mock external dependencies
 - Test error states and edge cases
 
+### End-to-End Tests
+- Ensure Playwright is installed (`npx playwright install` on first run)
+- Run E2E tests with:
+  ```bash
+  npm run test:e2e
+  ```
+- The command automatically launches the Vite dev server defined in
+  `playwright.config.ts`. The server should be available at
+  `http://localhost:3000`.
+- If you see a timeout error, verify that the `webServer.url` and
+  `use.baseURL` values in `playwright.config.ts` match the port defined in
+  `vite.config.ts` (3000 by default).
+- Test reports are written to the `playwright-report/` directory.
+
 ## Performance
 
 ### Code Splitting

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3001',
+    // The Vite dev server runs on port 3000 in this project
+    // so point Playwright to the same address
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -75,8 +77,10 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3001',
+    // Ensure Playwright waits for the Vite dev server on the correct port
+    url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    // Allow a little extra time for initial build on CI
+    timeout: 180 * 1000,
   },
 });


### PR DESCRIPTION
## Summary
- point Playwright to the dev server on port 3000
- allow more startup time for the dev server
- document how to run E2E tests in `DEVELOPER_GUIDE.md`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: missing browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b14a60f548321888ec45b7202384d